### PR TITLE
ARM 64 is not compatible with psycopg2

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,6 +25,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: leadvic/etl-pipeline-for-pterodactyl:latest


### PR DESCRIPTION
ARM 64 is not compatible with psycopg2 library from python:

https://stackoverflow.com/questions/71652499/cant-install-psycopg2-binary-on-macos-monterey-12-3